### PR TITLE
feat: disable tracing on `mod_status` handler

### DIFF
--- a/mod_datadog/src/tracing/hooks.cpp
+++ b/mod_datadog/src/tracing/hooks.cpp
@@ -81,6 +81,12 @@ apr_status_t delete_span(void* data) {
 }  // namespace
 
 int on_fixups(request_rec* r, Tracer& g_tracer, module* datadog_module) {
+  // NOTE(@dmehala): do not trace `mod_status` handler.
+  if (r->handler != nullptr &&
+      std::string_view(r->handler) == "server-status") {
+    return DECLINED;
+  }
+
   Span* span = nullptr;
   InjectionOptions injection_opts;
 


### PR DESCRIPTION
# Description

For context:
> The Status module allows a server administrator to find out how well their server is performing. A HTML page is presented that gives the current server statistics in an easily readable form. 

For now, [mod_status](https://httpd.apache.org/docs/2.4/mod/mod_status.html) is used by the Datadog Agent to retrieve stats on Apache on a regular interval. 
There is little need to trace `mod_status` handler except inflating the bill and wasting resources. This PR prevent tracing requests handled by `mod_status`.