### PR TITLE
chore(build): Build using llvm and musl

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -14,13 +14,13 @@ jobs:
     needs: format
     runs-on: ubuntu-22.04
     container:
-      image: datadog/docker-library:httpd-datadog-ci-2.4
+      image: datadog/docker-library:httpd-datadog-ci-2.4-e5dd7ac
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Configure
-        run: cmake -B build -DHTTPD_SRC_DIR=/httpd -DHTTPD_DATADOG_ENABLE_COVERAGE=1 .
+        run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=/sysroot/x86_64-none-linux-musl/Toolchain.cmake -DHTTPD_SRC_DIR=/httpd -DHTTPD_DATADOG_ENABLE_COVERAGE=1 -DCMAKE_BUILD_TYPE=Debug .
       - name: Build
         run: |
           cmake --build build -j --verbose
@@ -30,27 +30,24 @@ jobs:
         with:
           name: mod_datadog_artifact
           path: dist/lib/mod_datadog.so
-      - name: Export GNCO files
-        uses: actions/upload-artifact@v3
-        with:
-          name: gcno-artifacts
-          path: build/mod_datadog/CMakeFiles/mod_datadog.dir/src/**/*.gcno
+          if-no-files-found: error
 
   test:
     needs: build
     runs-on: ubuntu-22.04
     container:
-      image: datadog/docker-library:httpd-datadog-ci-2.4
+      image: datadog/docker-library:httpd-datadog-ci-2.4-e5dd7ac
     env:
       DD_ENV: ci
       DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
       DD_SERVICE: httpd-tests
       DD_CIVISIBILITY_AGENTLESS_ENABLED: true
+      LLVM_PROFILE_FILE: /tmp/httpd.%p-%m.profraw
     steps:
       - uses: actions/checkout@v4
       - run: |
-          pip install -r requirements.txt
-          pip install ddtrace
+          pip install -r requirements.txt --break-system-packages
+          pip install ddtrace --break-system-packages
       - name: Import library from build job
         uses: actions/download-artifact@v3
         with:
@@ -60,17 +57,10 @@ jobs:
         run: pytest --ddtrace test/integration-test --module-path dist/lib/mod_datadog.so --bin-path /httpd/httpd-build/bin/apachectl --log-dir $(pwd)/logs -m smoke
       - name: Run Integration Tests
         run: pytest --ddtrace test/integration-test --module-path dist/lib/mod_datadog.so --bin-path /httpd/httpd-build/bin/apachectl --log-dir $(pwd)/logs -m ci
-    # In order to compute the correct coverage we need the .gnco and .gcda files
-    # The .gnco files are created during the build job therefore we export/import them.
-    # Otherwise they would be lost after the end of the build job. The .gcda files
-    # are automatically created after tests execution
-      - name: Import GNCO files
-        uses: actions/download-artifact@v3
-        with: 
-          name: gcno-artifacts
-          path: build/mod_datadog/CMakeFiles/mod_datadog.dir/src
       - name: Generate code coverage
-        run: lcov --capture --directory build/mod_datadog/CMakeFiles/mod_datadog.dir/src --output-file coverage.lcov
+        run: |
+          llvm-profdata merge -sparse /tmp/*.profraw -o /tmp/default.profdata 
+          llvm-cov export dist/lib/mod_datadog.so -format=lcov -instr-profile=/tmp/default.profdata -ignore-filename-regex=/httpd/ > coverage.lcov
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -78,4 +68,6 @@ jobs:
           name: github-actions
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: DataDog/httpd-datadog
+          os: alpine
+          fail_ci_if_error: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,13 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     container:
-      image: datadog/docker-library:httpd-datadog-ci-2.4
+      image: datadog/docker-library:httpd-datadog-ci-2.4-e5dd7ac
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Configure
-        run: cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DHTTPD_SRC_DIR=/httpd .
+        run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=/sysroot/x86_64-none-linux-musl/Toolchain.cmake -DHTTPD_SRC_DIR=/httpd -DCMAKE_BUILD_TYPE=RelWithDebInfo -DHTTPD_DATADOG_PATCH_AWAY_LIBC=1 .
       - name: Build
         run: |
           cmake --build build -j --verbose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,11 @@ project(httpd-datadog)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-option(HTTPD_DATADOG_ENABLE_COVERAGE OFF)
-option(HTTPD_DATADOG_ENABLE_RUM OFF)
+set(ZLIB_USE_STATIC_LIBS ON)
+
+option(HTTPD_DATADOG_ENABLE_RUM "Enable RUM product" OFF)
+option(HTTPD_DATADOG_ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
+option(HTTPD_DATADOG_PATCH_AWAY_LIBC "Patch away libc dependency" OFF)
 
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE ReleaseWithDeb)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,16 @@
 #
 # To publish:
 #  docker buildx build --platform linux/amd64,linux/arm64 --output=type=image,name=datadog/docker-library:build-httpd-2.4,push=true .
-FROM datadog/docker-library:dd-trace-cpp-ci
+FROM public.ecr.aws/b1o7r7e0/nginx_musl_toolchain:latest
 
-ADD scripts/setup-httpd.sh setup-httpd.sh
+ADD scripts/setup-httpd.py setup-httpd.py
 
-RUN apt update \
- && apt install -y libpcre3 libpcre3-dev expat libexpat-dev autoconf libtool libtool-bin
+RUN apk update \
+ && apk add --no-cache expat expat-dev autoconf libtool py-pip gpg gpg-agent
 
-RUN python3 ./scripts/setup-httpd.py -o httpd 2.4.58 \
+RUN python3 ./setup-httpd.py -o httpd 2.4.58 \
  && cd httpd \
  && ./configure --with-included-apr --prefix=$(pwd)/httpd-build --enable-mpms-shared="all" \
- && make \
- && make install
+ && make -j \
+ && make -j install
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+COMMIT_SHA ?= $(shell git rev-parse --short HEAD)
+DOCKER_REPO ?= datadog/docker-library
+
+.PHONY: push-ci-images
+push-ci-images:
+	docker build --progress=plain --platform linux/amd64 -t $(DOCKER_REPO):httpd-datadog-ci-2.4-$(COMMIT_SHA)-amd64 .
+	docker push $(DOCKER_REPO):httpd-datadog-ci-2.4-$(COMMIT_SHA)-amd64
+	docker build --progress=plain --platform linux/arm64 -t $(DOCKER_REPO):httpd-datadog-ci-2.4-$(COMMIT_SHA)-arm64 .
+	docker push $(DOCKER_REPO):httpd-datadog-ci-2.4-$(COMMIT_SHA)-arm64
+	docker buildx imagetools create -t $(DOCKER_REPO):httpd-datadog-ci-2.4-$(COMMIT_SHA) \
+			$(DOCKER_REPO):httpd-datadog-ci-2.4-$(COMMIT_SHA)-amd64 \
+			$(DOCKER_REPO):httpd-datadog-ci-2.4-$(COMMIT_SHA)-arm64
+	docker push $(DOCKER_REPO):httpd-datadog-ci-2.4-$(COMMIT_SHA)

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -22,3 +22,17 @@ function(split_debug_info target_name)
     endif()
   endif()
 endfunction()
+
+function(patch_away_libc target)
+  if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    return()
+  endif()
+
+  find_program(PATCHELF patchelf)
+  if (PATCHELF STREQUAL "PATCHELF-NOTFOUND")
+    message(WARNING "Patchelf not found. Can't build glibc + musl binaries")
+  else()
+    add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND patchelf --remove-needed libc.musl-${CMAKE_SYSTEM_PROCESSOR}.so.1 $<TARGET_FILE:${target}>)
+  endif()
+endfunction()

--- a/mod_datadog/CMakeLists.txt
+++ b/mod_datadog/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library(
     src/tracing/hooks.cpp
 )
 
+set_property(TARGET mod_datadog PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 if (HTTPD_DATADOG_ENABLE_RUM)
   target_compile_definitions(
     mod_datadog
@@ -65,23 +67,45 @@ target_link_libraries(mod_datadog
     fmt
 )
 
-if (HTTPD_DATADOG_ENABLE_COVERAGE)
-  target_compile_options(mod_datadog
-    PRIVATE
-      -ftest-coverage
-      -g
-      -O0
-      -fprofile-arcs
-  )
-  target_link_libraries(mod_datadog
-    PRIVATE
-     -fprofile-arcs
-  )
+if(HTTPD_DATADOG_ENABLE_COVERAGE)
+  if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(FATAL_ERROR "HTTPD_DATADOG_ENABLE_COVERAGE is only supported with clang")
+  else()
+    target_compile_options(mod_datadog
+      PRIVATE
+        -fprofile-instr-generate 
+        -fcoverage-mapping 
+        -mllvm 
+        -runtime-counter-relocation=true
+        -enable-name-compression=false
+    )
+    target_link_options(mod_datadog
+      PRIVATE
+        -fprofile-instr-generate 
+        -mllvm 
+        -runtime-counter-relocation=true
+        -enable-name-compression=false
+    )
+  endif()
 endif ()
 
-if (APPLE)
-  target_link_options(mod_datadog PRIVATE -undefined dynamic_lookup)
-endif ()
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(LINKER_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/symbols.ld)
+  set_target_properties(mod_datadog PROPERTIES LINK_DEPENDS ${LINKER_SCRIPT})
+  target_link_options(mod_datadog PRIVATE "-Wl,--version-script=${LINKER_SCRIPT}")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  if(CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+    target_link_options(mod_datadog PRIVATE -undefined dynamic_lookup)
+  endif()
+
+  set(EXPORTED_SYMBOLS ${CMAKE_CURRENT_LIST_DIR}/symbols.ld-prime)
+  set_target_properties(mod_datadog PROPERTIES LINK_DEPENDS ${EXPORTED_SYMBOLS})
+  target_link_options(mod_datadog PRIVATE "-Wl,-exported_symbols_list" "-Wl,${EXPORTED_SYMBOLS}")
+endif()
+
+if(HTTPD_DATADOG_PATCH_AWAY_LIBC)
+  patch_away_libc(mod_datadog)
+endif()
 
 install(
   TARGETS mod_datadog
@@ -94,3 +118,4 @@ install(
 if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
   split_debug_info(mod_datadog)
 endif()
+

--- a/mod_datadog/symbols.ld
+++ b/mod_datadog/symbols.ld
@@ -1,0 +1,5 @@
+{
+	global:
+    datadog_module;
+	local: *; /* Hide all other symbols */
+};

--- a/mod_datadog/symbols.ld-prime
+++ b/mod_datadog/symbols.ld-prime
@@ -1,0 +1,3 @@
+# `nm -m` to get the list of symbols
+# For more details: <https://developer.apple.com/library/archive/documentation/Performance/Conceptual/CodeFootprint/Articles/ReducingExports.html
+_datadog_module


### PR DESCRIPTION
# Description
This PR adds the possibility to build the Apache HTTP Module using llvm and musl. This aims to solve compatibility issues with glibc. Also, it is mostly a copy-pasta from @cataphract's work on NGINX. Thanks ;)