### PR TITLE
chore: log module infos

### DIFF
--- a/mod_datadog/CMakeLists.txt
+++ b/mod_datadog/CMakeLists.txt
@@ -77,14 +77,12 @@ if(HTTPD_DATADOG_ENABLE_COVERAGE)
         -fcoverage-mapping 
         -mllvm 
         -runtime-counter-relocation=true
-        -enable-name-compression=false
     )
     target_link_options(mod_datadog
       PRIVATE
         -fprofile-instr-generate 
         -mllvm 
         -runtime-counter-relocation=true
-        -enable-name-compression=false
     )
   endif()
 endif ()

--- a/mod_datadog/src/version.h
+++ b/mod_datadog/src/version.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <string_view>
+
+// The release version at or before this code revision, e.g. "v1.0.3".
+inline constexpr std::string_view mod_datadog_version = "1.0.3";


### PR DESCRIPTION
# description
straightforward.

Changes:
- log at startup module informations.
- bump version to `v1.0.3`.
- remove `-enable-name-compression=false`.