### PR TITLE
fix(rum): Relax content-type criteria

### DIFF
--- a/mod_datadog/src/utils.h
+++ b/mod_datadog/src/utils.h
@@ -4,6 +4,7 @@
 #include <httpd.h>
 
 #include <string>
+#include <string_view>
 
 namespace datadog::common::utils {
 
@@ -23,6 +24,10 @@ inline std::string make_httpd_version() {
 
   return fmt::format("{}.{}.{}", httpd_version.major, httpd_version.minor,
                      httpd_version.patch);
+}
+
+inline bool contains(std::string_view text, std::string_view pattern) {
+  return text.find(pattern) != text.npos;
 }
 
 }  // namespace datadog::common::utils


### PR DESCRIPTION
# Description
Improve logic injection for RUM by relaxing the content-type check to match responses that include `text/html` rather than requiring an exact match.

Changes:
  - Update Content-Type criteria to allow injection when it contains `text/html` instead of requiring a strict equality match.
  - Prevent injection into compressed responses.
  - Extract the injection criteria into a `should_inject` function.