### PR TITLE
fix(rum): injection failure for `text/html`

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_subdirectory(dd-trace-cpp)
 
 if (HTTPD_DATADOG_ENABLE_RUM)
-  corrosion_import_crate(MANIFEST_PATH inject-browser-sdk/lib/Cargo.toml)
+  corrosion_import_crate(MANIFEST_PATH inject-browser-sdk/Cargo.toml)
 
   corrosion_experimental_cbindgen(
-    TARGET injectbrowsersdk
+    TARGET inject_browser_sdk_ffi
     HEADER_NAME injectbrowsersdk.h
     FLAGS --config ${CMAKE_SOURCE_DIR}/deps/cbindgen.toml
   )

--- a/mod_datadog/CMakeLists.txt
+++ b/mod_datadog/CMakeLists.txt
@@ -27,7 +27,7 @@ if (HTTPD_DATADOG_ENABLE_RUM)
   target_link_libraries(
     mod_datadog
     PRIVATE
-      injectbrowsersdk
+      inject_browser_sdk_ffi 
       rapidjson
   )
 endif ()


### PR DESCRIPTION
Injection was failing when the `Content-Type` header contained `text/html`.  

### Changes:  
- Updated dependency on `inject-browser-sdk` to the latest build at HEAD to resolve the issue.