### PR TITLE
feat: add support for inferred services

### DIFF
--- a/mod_datadog/src/tracing/hooks.cpp
+++ b/mod_datadog/src/tracing/hooks.cpp
@@ -63,8 +63,13 @@ static SpanConfig make_span_config(
   }
 
   datadog::tracing::SpanConfig options;
-  options.name =
-      (r->proxyreq != PROXYREQ_NONE) ? "httpd.proxy" : "httpd.request";
+  if (r->proxyreq != PROXYREQ_NONE) {
+    options.name = "httpd.proxy";
+    tags.emplace("span.kind", "client");
+  } else {
+    options.name = "httpd.request";
+    tags.emplace("span.kind", "server");
+  }
   options.resource = resource_name;
   options.tags = std::move(tags);
 


### PR DESCRIPTION
# Description
Read more about inferred services on [our public website](https://docs.datadoghq.com/tracing/services/inferred_services/?tab=agentv7551).

Changes:
  - Add `span.kind` tag to enhance support for inferred services.