### PR TITLE
chore(ci): update build image

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -14,7 +14,7 @@ jobs:
     needs: format
     runs-on: ubuntu-22.04
     container:
-      image: datadog/docker-library:httpd-datadog-ci-2.4-e5dd7ac
+      image: datadog/docker-library:httpd-datadog-ci-2.4-cdb3cb2
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,7 +38,7 @@ jobs:
     needs: build
     runs-on: ubuntu-22.04
     container:
-      image: datadog/docker-library:httpd-datadog-ci-2.4-e5dd7ac
+      image: datadog/docker-library:httpd-datadog-ci-2.4-cdb3cb2
     env:
       DD_ENV: ci
       DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     container:
-      image: datadog/docker-library:httpd-datadog-ci-2.4-e5dd7ac
+      image: datadog/docker-library:httpd-datadog-ci-2.4-cdb3cb2
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
A client has a GNU C incompatibility when using auto injection for RUM in RHEL8.8.

We provided a fix in nginx which should also fixes this issue. The fix is in the last version of ngx_musl_toolchain so we update the httpd ci image to benefit from the fix