### PR TITLE
Add Datadog code coverage upload

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Upload coverage to Datadog
         if: always()
         continue-on-error: true
-        uses: DataDog/coverage-upload-github-action@v1
+        uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
         with:
           api_key: ${{ secrets.DD_API_KEY_CI_APP }}
           files: coverage.lcov

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -76,4 +76,12 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: DataDog/httpd-datadog
           fail_ci_if_error: true
+      - name: Upload coverage to Datadog
+        if: always()
+        continue-on-error: true
+        uses: DataDog/coverage-upload-github-action@v1
+        with:
+          api_key: ${{ secrets.DD_API_KEY_CI_APP }}
+          files: coverage.lcov
+          format: lcov
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -79,9 +79,10 @@ jobs:
       - name: Upload coverage to Datadog
         if: always()
         continue-on-error: true
-        uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
-        with:
-          api_key: ${{ secrets.DD_API_KEY_CI_APP }}
-          files: coverage.lcov
-          format: lcov
+        run: |
+          curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
+          chmod +x /usr/local/bin/datadog-ci
+          datadog-ci coverage upload --format=lcov coverage.lcov
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -80,9 +80,9 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
-          chmod +x /usr/local/bin/datadog-ci
-          datadog-ci coverage upload --format=lcov coverage.lcov
+          curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output /tmp/datadog-ci
+          chmod +x /tmp/datadog-ci
+          /tmp/datadog-ci coverage upload --format=lcov coverage.lcov
         env:
           DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -80,9 +80,8 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output /tmp/datadog-ci
-          chmod +x /tmp/datadog-ci
-          /tmp/datadog-ci coverage upload --format=lcov coverage.lcov
+          apk add --no-cache nodejs npm
+          npx @datadog/datadog-ci@latest coverage upload --format=lcov coverage.lcov
         env:
           DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
 


### PR DESCRIPTION
## What does this PR do?

We're migrating Datadog repositories from Codecov to [Datadog Code Coverage](https://docs.datadoghq.com/code_analysis/code_coverage/) for tracking test coverage. This PR is the first step: it adds a Datadog coverage upload **alongside** the existing Codecov upload so we can run both systems in parallel and verify parity before switching over.

## Changes

- Added `DataDog/coverage-upload-github-action@v1` step after the existing Codecov upload in the `dev.yml` workflow test job
- Uses `DD_API_KEY_CI_APP` secret (already available in the repo for CI Visibility)
- Coverage format: LCOV (generated by `llvm-cov export`)
- The existing Codecov uploads are **unchanged** — nothing is removed or modified
- The upload uses `continue-on-error: true` so it cannot block CI

## Why are we doing this?

As part of a company-wide effort, we're consolidating code coverage reporting into Datadog's own Code Coverage product. This gives us:
- Coverage data integrated directly into Datadog CI Visibility
- PR gates and coverage checks natively in Datadog
- No dependency on a third-party service (Codecov) for coverage reporting

## Validation

Pending — `dev.yml` triggers on push only (not PRs), so the Datadog upload will run after merge.

## Next steps (not in this PR)

Once this PR is merged and we've confirmed Datadog coverage is stable over several commits:
1. Remove the Codecov upload steps and `CODECOV_TOKEN` secret
2. Optionally configure PR gates in `code-coverage.datadog.yml`

## No action needed from reviewers beyond normal review

This is a low-risk, additive change. The new upload step runs independently of the existing CI pipeline and cannot cause test failures.