### PR TITLE
Update dd-trace-cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,57 +1,39 @@
-# Prerequisites
-*.d
-
-# Compiled Object files
-*.slo
+*.a
+*.app
+*.bak
+*.dll
+*.dylib
+*.exe
+*.la
+*.lai
+*.lib
 *.lo
+*.log
 *.o
 *.obj
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-*.smod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
 *.out
-*.app
-
-.DS_Store
+*.slo
+*.so
 
 .cache/
+.claude/
 .vscode/
 
+.DS_Store
+compile_commands.json
+
+__pycache__/
+build-rum/
 build/
 httpd-*/
-__pycache__/
+httpd/
 venv/
 
-compile_commands.json
-build-rum/
-*.bak
-
-# Integration tests
-test/integration-test/.venv/
-test/integration-test/uv.lock
-test/integration-test/.pytest_cache/
 test/integration-test/.coverage
+test/integration-test/.pytest_cache/
+test/integration-test/.venv/
+test/integration-test/*.conf.tmp
 test/integration-test/htmlcov/
 test/integration-test/log-*/
 test/integration-test/logs/
-test/integration-test/*.conf.tmp
-test/integration-test/*.log
+test/integration-test/uv.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,12 +51,9 @@ cmake --build build -j
 ```
 
 ### Testing
-For now there are only integration tests. `docker-compose` orchestrate a runtime environment and the test suite interact with
-It should be as simple as:
 
-````sh
-pytest test/integration-test
-````
+For now there are only [integration tests](./test/integration-test/).
 
 ## How to Debug
+
 Run with `-X`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing 
+# Contributing
 
 ## Fork, Clone, Branch and Create your PR
 
@@ -8,7 +8,7 @@ git submodule update --init --recursive
 ```
 
 ### Rules
-- **Follow the pattern of what you already see in the code.**
+- Follow the pattern of what you already see in the code.
 - Follow the coding style.
 
 # Development
@@ -27,37 +27,19 @@ Once you got a valid `python` installation, install all the dependencies with
 pip install -r requirements.txt
 ````
 
-Finally, you need HTTPD source code available. Use [scripts/setup-httpd.py](./scripts/setup-httpd.py) script:
-
-````shell
-python scripts/setup-httpd.py
-
-usage: Download Apache HTTP Server and its dependencies [-h] [-v VERBOSE] [-o OUTPUT] version
-
-positional arguments:
-  version               HTTPD version to download
-
-options:
-  -h, --help            show this help message and exit
-  -v VERBOSE, --verbose VERBOSE
-                        Increase verbosity level
-  -o OUTPUT, --output OUTPUT
-                        Directory where HTTPD will be extracted
-````
-
 ## Compiling
 
 ### Setup `httpd`
 
-In order to build the module you have to configure httpd first:
+In order to build the module you have to configure `httpd` with the [scripts/setup-httpd.py](./scripts/setup-httpd.py) script:
+
 ```sh
 python scripts/setup-httpd.py -o httpd $HTTPD_VERSION
-cd httpd 
-
-./configure --with-included-apr --prefix=$(pwd)/httpd-build --enable-mpms-shared="all" 
+cd httpd
+./configure --with-included-apr --prefix=$(pwd)/httpd-build --enable-mpms-shared="all"
 ```
 
-### Build the module
+### Build the Module
 
 CMake is our build system. If you are not familiar with CMake, read [the tutorial.](https://cmake.org/cmake/help/latest/guide/tutorial/index.html)
 
@@ -75,6 +57,6 @@ It should be as simple as:
 ````sh
 pytest test/integration-test
 ````
-## How to debug
-Run with `-X`
 
+## How to Debug
+Run with `-X`.

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,1 +1,6 @@
 add_subdirectory(dd-trace-cpp)
+
+# Force POSITION_INDEPENDENT_CODE (PIC) because mod_datadog.so is loaded via
+# dlopen, but dd-trace-cpp sets this based on BUILD_SHARED_LIBS, whereas we
+# link with the static library.
+set_target_properties(dd-trace-cpp-objects PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/mod_datadog/CMakeLists.txt
+++ b/mod_datadog/CMakeLists.txt
@@ -79,7 +79,7 @@ target_compile_options(mod_datadog
   PRIVATE -Wall -Wextra
 )
 
-add_dependencies(mod_datadog dd_trace_cpp-static httpd fmt)
+add_dependencies(mod_datadog dd-trace-cpp-static httpd fmt)
 
 target_include_directories(
   mod_datadog
@@ -97,10 +97,10 @@ set_target_properties(
 
 target_include_directories(mod_datadog PRIVATE httpd)
 
-target_link_libraries(mod_datadog 
+target_link_libraries(mod_datadog
   PRIVATE
-    dd_trace_cpp-static 
-    httpd 
+    dd-trace-cpp-static
+    httpd
     fmt
 )
 

--- a/mod_datadog/src/mod_datadog.cpp
+++ b/mod_datadog/src/mod_datadog.cpp
@@ -292,7 +292,7 @@ void init_tracer(datadog::tracing::TracerConfig& tracer_conf) {
     // default value when no service name has been provided.
     auto& service_name_metadata =
         validated_config->metadata[datadog::tracing::ConfigName::SERVICE_NAME];
-    service_name_metadata.origin =
+    service_name_metadata.back().origin =
         datadog::tracing::ConfigMetadata::Origin::DEFAULT;
   }
 

--- a/test/integration-test/.env.example
+++ b/test/integration-test/.env.example
@@ -5,10 +5,6 @@
 #
 # Then source it before running tests:
 #   source .env
-#   make test
-
-# Path to Apache apachectl binary
-HTTPD_BIN_PATH=/usr/local/apache2/bin/apachectl
 
 # Path to compiled mod_datadog.so module
 HTTPD_MODULE_PATH=/path/to/mod_datadog.so


### PR DESCRIPTION
It was needed to update `dd-trace-cpp` because the local build was failing because of a too old version of `nlohmann/json`.

## Details About the Old `nlohmann/json` Dependency Issue
 We got:
```
cmake -B build -DCMAKE_BUILD_TYPE=Release -DHTTPD_SRC_DIR=httpd .
[…]
CMake Error at build/_deps/json-src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```
This came from `deps/dd-trace-cpp/cmake/deps/json.cmake`:
```
  URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz
```
which was actually incoherent with `deps/dd-trace-cpp/src/datadog/json.hpp`:
```
// |  |  |__   |  |  | | | |  version 3.12.0
```

## Tricky Technical Change for Linking `dd-trace-cpp`
In October 2025, `dd-trace-cpp` introduced the following building change, [line 229 of CMakeLists.txt](https://github.com/DataDog/dd-trace-cpp/commit/b625050d23cd10623dc2f2a7477f11008fc775dd#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR229):
```
set_target_properties(dd-trace-cpp-objects
  PROPERTIES
    VERIFY_INTERFACE_HEADER_SETS ON
    POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS}
)
```
This makes `POSITION_INDEPENDENT_CODE` on only when building a shared lib.
But in the Apache plugin, we use the static library that gets linked into `mod_datadog.so`, which is loaded via `dlopen`. And any object file that ends up in `.so` file loaded via `dlopen` must be compiled with `-fPIC`, even when going through a static library intermediary. (Else, we get a linker error because initial-exec TLS relocation are incompatible with `dlopen`.)
This is fixed by overriding `POSITION_INDEPENDENT_CODE` after `add_subdirectory(dd-trace-cpp)` in `deps/CMakeLists.txt`.