### PR TITLE
Replace npx datadog-ci with coverage-upload-github-action

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -71,7 +71,7 @@ jobs:
           llvm-profdata merge -sparse /tmp/*.profraw -o /tmp/default.profdata
           llvm-cov export dist/lib/mod_datadog.so -format=lcov -instr-profile=/tmp/default.profdata -ignore-filename-regex=/httpd/ > coverage.lcov
       - name: Upload code coverage report to Datadog
-        uses: DataDog/coverage-upload-github-action@v1
+        uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
         with:
           api_key: ${{ secrets.DD_API_KEY_CI_APP }}
           files: coverage.lcov

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -71,6 +71,8 @@ jobs:
           llvm-profdata merge -sparse /tmp/*.profraw -o /tmp/default.profdata
           llvm-cov export dist/lib/mod_datadog.so -format=lcov -instr-profile=/tmp/default.profdata -ignore-filename-regex=/httpd/ > coverage.lcov
       - name: Upload code coverage report to Datadog
-        run: npx @datadog/datadog-ci@latest coverage upload --format=lcov coverage.lcov
-        env:
-          DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
+        uses: DataDog/coverage-upload-github-action@v1
+        with:
+          api_key: ${{ secrets.DD_API_KEY_CI_APP }}
+          files: coverage.lcov
+          format: lcov


### PR DESCRIPTION
## Summary
- Replaces the `npx @datadog/datadog-ci@latest coverage upload` step with the `DataDog/coverage-upload-github-action@v1` composite action
- The action installs a standalone `datadog-ci` binary instead of using `npx`, which avoids downloading Node.js packages on every run
- This is a follow-up to PR #46 which migrated from Codecov to Datadog coverage upload

## Details
The `coverage-upload-github-action@v1` wraps the same `datadog-ci coverage upload` command but:
1. Installs the `datadog-ci` standalone binary (no Node.js/npx dependency needed)
2. Provides a cleaner, declarative interface via action inputs
3. Should be slightly faster since it avoids npm package resolution

## Test plan
- [ ] Verify the coverage upload step completes successfully in CI
- [ ] Confirm coverage data appears in [Datadog Code Coverage](https://app.datadoghq.com/ci/code-coverage/github.com%2Fdatadog%2Fhttpd-datadog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)