### PR TITLE
Replace npx datadog-ci by coverage-upload GitHub action

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -71,6 +71,8 @@ jobs:
           llvm-profdata merge -sparse /tmp/*.profraw -o /tmp/default.profdata
           llvm-cov export dist/lib/mod_datadog.so -format=lcov -instr-profile=/tmp/default.profdata -ignore-filename-regex=/httpd/ > coverage.lcov
       - name: Upload code coverage report to Datadog
-        run: npx @datadog/datadog-ci@latest coverage upload --format=lcov coverage.lcov
-        env:
-          DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
+        uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
+        with:
+          api_key: ${{ secrets.DD_API_KEY_CI_APP }}
+          files: coverage.lcov
+          format: lcov

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       # See in Makefile where this image comes from.
-      image: datadog/docker-library:httpd-datadog-ci-28219c0ef3e00f1e3d5afcab61a73a5e9bd2a9b957d7545556711cce2a6262cd
+      image: datadog/docker-library:httpd-datadog-ci-bf4e353dec1442b7864fddc3c2618b8541eed4c04fe2ab88f2a4c2ebea61df91
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       # See in Makefile where this image comes from.
-      image: datadog/docker-library:httpd-datadog-ci-28219c0ef3e00f1e3d5afcab61a73a5e9bd2a9b957d7545556711cce2a6262cd
+      image: datadog/docker-library:httpd-datadog-ci-bf4e353dec1442b7864fddc3c2618b8541eed4c04fe2ab88f2a4c2ebea61df91
     env:
       DD_ENV: ci
       DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
@@ -71,7 +71,8 @@ jobs:
           llvm-profdata merge -sparse /tmp/*.profraw -o /tmp/default.profdata
           llvm-cov export dist/lib/mod_datadog.so -format=lcov -instr-profile=/tmp/default.profdata -ignore-filename-regex=/httpd/ > coverage.lcov
       - name: Upload code coverage report to Datadog
-        uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
+        # The commit hash comes from the release of the action: https://github.com/DataDog/coverage-upload-github-action/releases
+        uses: DataDog/coverage-upload-github-action@f80c0e6e64e5d20d6af251ba00361eeaebc7ff99 # v1.0.2
         with:
           api_key: ${{ secrets.DD_API_KEY_CI_APP }}
           files: coverage.lcov

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -72,7 +72,7 @@ jobs:
           llvm-cov export dist/lib/mod_datadog.so -format=lcov -instr-profile=/tmp/default.profdata -ignore-filename-regex=/httpd/ > coverage.lcov
       - name: Upload code coverage report to Datadog
         # The commit hash comes from the release of the action: https://github.com/DataDog/coverage-upload-github-action/releases
-        uses: DataDog/coverage-upload-github-action@f80c0e6e64e5d20d6af251ba00361eeaebc7ff99 # v1.0.2
+        uses: DataDog/coverage-upload-github-action@6c4bd935248daa6f0ef94e3e6ba71ad5ad079998 # v1.0.3
         with:
           api_key: ${{ secrets.DD_API_KEY_CI_APP }}
           files: coverage.lcov

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -72,7 +72,7 @@ jobs:
           llvm-cov export dist/lib/mod_datadog.so -format=lcov -instr-profile=/tmp/default.profdata -ignore-filename-regex=/httpd/ > coverage.lcov
       - name: Upload code coverage report to Datadog
         # The commit hash comes from the release of the action: https://github.com/DataDog/coverage-upload-github-action/releases
-        uses: DataDog/coverage-upload-github-action@6c4bd935248daa6f0ef94e3e6ba71ad5ad079998 # v1.0.3
+        uses: DataDog/coverage-upload-github-action@2ba057033351887422f8eb0203d1990c3acbc8c5 # v1.0.4
         with:
           api_key: ${{ secrets.DD_API_KEY_CI_APP }}
           files: coverage.lcov

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -74,5 +74,6 @@ jobs:
         # See https://github.com/DataDog/coverage-upload-github-action/releases
         uses: DataDog/coverage-upload-github-action@2ba057033351887422f8eb0203d1990c3acbc8c5 # v1.0.4
         with:
+          api_key: ${{ secrets.DD_API_KEY_CI_APP }}
           files: coverage.lcov
           format: lcov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       # See in Makefile where this image comes from.
-      image: datadog/docker-library:httpd-datadog-ci-28219c0ef3e00f1e3d5afcab61a73a5e9bd2a9b957d7545556711cce2a6262cd
+      image: datadog/docker-library:httpd-datadog-ci-bf4e353dec1442b7864fddc3c2618b8541eed4c04fe2ab88f2a4c2ebea61df91
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       # See in Makefile where this image comes from.
-      image: datadog/docker-library:httpd-datadog-ci-28219c0ef3e00f1e3d5afcab61a73a5e9bd2a9b957d7545556711cce2a6262cd
+      image: datadog/docker-library:httpd-datadog-ci-bf4e353dec1442b7864fddc3c2618b8541eed4c04fe2ab88f2a4c2ebea61df91
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.gitlab/Dockerfile
+++ b/.gitlab/Dockerfile
@@ -82,10 +82,9 @@ RUN clang --sysroot /sysroot/${ARCH}-none-linux-musl/ -fpie -O2 -fno-omit-frame-
 RUN apk add --no-cache autoconf expat expat-dev gpg gpg-agent libtool pcre-dev pcre2-dev py-pip zip
 
 # Install dependencies for code coverage upload
-RUN apk add --no-cache nodejs npm
+RUN apk add --no-cache curl jq
 
 # Install Rust toolchain
-RUN apk add --no-cache curl
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -yq --default-toolchain 1.73.0 \
   && ln -s ~/.cargo/bin/cargo /usr/bin/cargo
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #   - Copy this hash here, and in the GitHub workflow files.
 #   - Run: make replicate-ci-image-for-github.
 
-CI_DOCKER_IMAGE_HASH ?= 28219c0ef3e00f1e3d5afcab61a73a5e9bd2a9b957d7545556711cce2a6262cd
+CI_DOCKER_IMAGE_HASH ?= bf4e353dec1442b7864fddc3c2618b8541eed4c04fe2ab88f2a4c2ebea61df91
 CI_IMAGE_FROM_GITLAB ?= registry.ddbuild.io/ci/httpd-datadog/amd64:$(CI_DOCKER_IMAGE_HASH)
 CI_IMAGE_IN_PUBLIC_REPO_FOR_GITHUB ?= datadog/docker-library:httpd-datadog-ci-$(CI_DOCKER_IMAGE_HASH)
 


### PR DESCRIPTION
This replaces the `npx @datadog/datadog-ci@latest coverage upload` step with the `DataDog/coverage-upload-github-action` action.
This action installs a standalone `datadog-ci` binary instead of using `npx`, which avoids downloading Node.js packages on every run.
This is safer (see [axios Compromised on npm](https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan)) (and should be slightly faster).