### PR TITLE
Fix local run of tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 ## Fork, Clone, Branch and Create your PR
 
 When cloning the repo, you have to initialize the submodules:
+
 ```sh
 git submodule update --init --recursive
 ```
@@ -21,20 +22,21 @@ git submodule update --init --recursive
 | `python` | 3.0+ | |
 | `cmake` | 3.12+ | |
 
-Once you got a valid `python` installation, install all the dependencies with
+Once you got a valid Python installation, install all the dependencies with:
 
-````shell
+```sh
 pip install -r requirements.txt
-````
+```
 
 ## Compiling
 
 ### Setup `httpd`
 
-In order to build the module you have to configure `httpd` with the [scripts/setup-httpd.py](./scripts/setup-httpd.py) script:
+In order to build the module you have to configure `httpd` with the [scripts/setup-httpd.py](./scripts/setup-httpd.py) script. Check what is the latest available version on [Apache website](https://httpd.apache.org), then:
 
 ```sh
-python scripts/setup-httpd.py -o httpd $HTTPD_VERSION
+export HTTPD_VERSION=2.4.66
+python scripts/setup-httpd.py $HTTPD_VERSION
 cd httpd
 ./configure --with-included-apr --prefix=$(pwd)/httpd-build --enable-mpms-shared="all"
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,16 @@ cd httpd
 ./configure --with-included-apr --prefix=$(pwd)/httpd-build --enable-mpms-shared="all"
 ```
 
+### Install Rust
+
+The RUM variant requires Rust to build:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Relaunch your terminal (or do `source ~/.cargo/env`).
+
 ### Build the Module
 
 CMake is our build system. If you are not familiar with CMake, read [the tutorial.](https://cmake.org/cmake/help/latest/guide/tutorial/index.html)

--- a/cmake/deps/fmt.cmake
+++ b/cmake/deps/fmt.cmake
@@ -13,6 +13,6 @@ if(NOT fmt_POPULATED)
   set(BUILD_SHARED_LIBS OFF)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-  add_subdirectory(${fmt_SOURCE_DIR} EXCLUDE_FROM_ALL)
+  add_subdirectory(${fmt_SOURCE_DIR} ${fmt_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 

--- a/scripts/setup-httpd.py
+++ b/scripts/setup-httpd.py
@@ -72,6 +72,9 @@ def main():
     args = parser.parse_args()
 
     args.output = os.path.abspath(args.output)
+    if os.path.exists(args.output):
+        print(f"Output directory '{args.output}' already exists. Please remove it before running this script.")
+        return 1
 
     if not subprocess.run("git -v", shell=True, stdout=subprocess.DEVNULL):
         print("git command must be available")

--- a/test/integration-test/README.md
+++ b/test/integration-test/README.md
@@ -82,7 +82,7 @@ DatadogRum On
 
 ## Docker Testing
 
-```bash
+```sh
 docker run --rm -v "$PWD:/workspace" -w /workspace \
   datadog/docker-library:httpd-datadog-ci-2.4-cdb3cb2 \
   sh -c "
@@ -100,12 +100,12 @@ docker run --rm -v "$PWD:/workspace" -w /workspace \
 **RUM build fails:** Check CMake output for missing dependencies (inject-browser-sdk is fetched automatically via CMake FetchContent)
 
 **Tests hang:** Port 8136 in use
-```bash
+```sh
 lsof -i :8136
 ```
 
 **Module issues:**
-```bash
+```sh
 ldd /path/to/mod_datadog.so
 apachectl -f /path/to/config.conf -t
 ```

--- a/test/integration-test/README.md
+++ b/test/integration-test/README.md
@@ -4,17 +4,6 @@ Integration tests for Apache httpd Datadog module using pytest.
 
 ## Quick Start
 
-### Prerequisites
-
-For local testing, install Apache development packages:
-```bash
-# Ubuntu/Debian
-sudo apt-get install apache2 apache2-dev libapr1-dev libaprutil1-dev
-
-# macOS
-brew install httpd
-```
-
 ### Setup
 
 ```bash
@@ -24,19 +13,25 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 # Install test dependencies
 cd test/integration-test && uv sync
 
-# Run all tests (auto-builds module variants as needed)
-uv run pytest --bin-path=/usr/sbin/apachectl -v
+# Run smoke tests (auto-builds module variants as needed)
+uv run pytest --bin-path=../../httpd/httpd-build/bin/apachectl -v -m smoke
+
+# Run CI tests
+uv run pytest --bin-path=../../httpd/httpd-build/bin/apachectl -v -m ci
 
 # Run RUM tests only (auto-builds with RUM support)
-uv run pytest --bin-path=/usr/sbin/apachectl -m requires_rum -v
+uv run pytest --bin-path=../../httpd/httpd-build/bin/apachectl -v -m requires_rum
+
+# Run all tests (auto-builds module variants as needed)
+uv run pytest --bin-path=../../httpd/httpd-build/bin/apachectl -v
 
 # Run with pre-built module (skip auto-build)
-uv run pytest --bin-path=/usr/sbin/apachectl \
-  --module-path=/path/to/mod_datadog.so -v
+uv run pytest --bin-path=../../httpd/httpd-build/bin/apachectl -v \
+  --module-path=/path/to/mod_datadog.so
 
 # Run specific test file
-uv run pytest --bin-path=/usr/sbin/apachectl \
-  scenarios/test_rum.py -v
+uv run pytest --bin-path=../../httpd/httpd-build/bin/apachectl -v \
+  scenarios/test_rum.py
 ```
 
 **Auto-Build Behavior:**

--- a/test/integration-test/conftest.py
+++ b/test/integration-test/conftest.py
@@ -290,12 +290,13 @@ def pytest_sessionstart(session: pytest.Session) -> None:
 
     log_dir = session.config.getoption("--log-dir")
     if log_dir:
+        log_dir = os.path.abspath(log_dir)
         if os.path.exists(log_dir):
             # TODO: Warn old logs will be removed and manage error
             shutil.rmtree(log_dir)
         os.mkdir(log_dir)
     else:
-        log_dir = tempfile.mkdtemp(prefix="log-httpd-tests-", dir=".")
+        log_dir = tempfile.mkdtemp(prefix="log-httpd-tests-")
 
     session.config.log_dir = log_dir
 

--- a/test/integration-test/pyproject.toml
+++ b/test/integration-test/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.8"
 dependencies = [
     "pytest>=7.4.4",
     "requests>=2.31.0",
-    "ddapm-test-agent==1.40.0",
+    "ddapm-test-agent>=1.40.0",
     "aiohttp>=3.9.0",
     "msgpack>=1.0.0",
 ]

--- a/test/integration-test/pyproject.toml
+++ b/test/integration-test/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.8"
 dependencies = [
     "pytest>=7.4.4",
     "requests>=2.31.0",
-    "ddapm-test-agent>=1.40.0",
+    "ddapm-test-agent==1.40.0",
     "aiohttp>=3.9.0",
     "msgpack>=1.0.0",
 ]

--- a/test/integration-test/pytest_plugins/integration_helpers.py
+++ b/test/integration-test/pytest_plugins/integration_helpers.py
@@ -47,6 +47,9 @@ def _build_module(
         # Configure
         print(f"   Configuring CMake...")
         cmake_args = ["cmake", "-B", str(build_dir)]
+        httpd_src_dir = project_root / "httpd"
+        if httpd_src_dir.exists():
+            cmake_args.append(f"-DHTTPD_SRC_DIR={httpd_src_dir}")
         if enable_rum:
             cmake_args.append("-DHTTPD_DATADOG_ENABLE_RUM=ON")
         cmake_args.append(".")
@@ -97,7 +100,7 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
     # Find project root
     test_dir = Path(__file__).parent.parent
-    project_root = test_dir.parent.parent
+    project_root = test_dir.parent.parent.resolve()
 
     if not (project_root / "CMakeLists.txt").exists():
         pytest.exit("Cannot find project root CMakeLists.txt", returncode=1)
@@ -131,14 +134,9 @@ def pytest_sessionstart(session: pytest.Session) -> None:
         session.config.module_path = explicit_path
         return
 
-    # Otherwise, use the auto-built modules
-    # Default to non-RUM module if both were built
-    if session.config._module_paths.get("no_rum"):
-        session.config.module_path = str(session.config._module_paths["no_rum"])
-    elif session.config._module_paths.get("rum"):
-        session.config.module_path = str(session.config._module_paths["rum"])
-    else:
-        pytest.exit("No module path available", returncode=1)
+    # Module paths are populated later in pytest_collection_modifyitems (after collection).
+    # Set a placeholder here; pytest_runtest_setup will assign the correct variant per test.
+    session.config.module_path = None
 
 
 def pytest_runtest_setup(item: pytest.Item) -> None:


### PR DESCRIPTION
This PR is made of some fixes to run locally the tests on MacOS.
With these fixes, one should now be able to run successfully the smoke tests, the CI tests, and the RUM tests.

A next PR will concentrate on emphasizing that one should run tests on Linux (via Docker) rather than on MacOS, and will also try to have all tests run on CI (currently, most tests are skipped in the CI!).