### PR TITLE
feat: seed root session ID for stable telemetry headers

### DIFF
--- a/mod_datadog/src/tracing/conf.cpp
+++ b/mod_datadog/src/tracing/conf.cpp
@@ -13,6 +13,7 @@ void init(TracerConfig& conf, RuntimeID& runtime_id, server_rec* s,
   conf.service_type = "server";
   conf.logger = std::make_shared<HttpdLogger>(s, datadog_module->module_index);
   conf.runtime_id = runtime_id;
+  conf.root_session_id = runtime_id.string();
   conf.integration_name = "httpd";
   conf.integration_version = common::utils::make_httpd_version();
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pytest==7.4.4
 requests==2.32.2
 flask==3.0.2
 msgpack==1.0.8
-git+https://github.com/Datadog/dd-apm-test-agent@v1.40.0
+git+https://github.com/Datadog/dd-apm-test-agent@v1.50.1

--- a/test/integration-test/conftest.py
+++ b/test/integration-test/conftest.py
@@ -187,6 +187,7 @@ class TestAgent:
             vcr_ci_mode=False,
             vcr_provider_map="",
             vcr_ignore_headers="",
+            vcr_json_body_normalizers="",
             dd_site="",
             dd_api_key="",
             disable_llmobs_data_forwarding=False,


### PR DESCRIPTION
## Summary
Seed `root_session_id` from the master-generated `RuntimeID` so all forked workers share the same root session ID for telemetry correlation.

## Related
- dd-trace-cpp PR: https://github.com/DataDog/dd-trace-cpp/pull/295
- nginx-datadog PR: https://github.com/DataDog/nginx-datadog/pull/345
- System tests PR: https://github.com/DataDog/system-tests/pull/6510