### PR TITLE
chore(ci): use dd-sts for system-tests test optimization

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -48,9 +48,7 @@ jobs:
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
       DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
     permissions:
-      contents: read
       id-token: write
-      packages: write
     with:
       library: cpp_httpd
       binaries_artifact: system_tests_binaries

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -60,4 +60,3 @@ jobs:
       parametric_job_count: 8
       skip_empty_scenarios: true
       push_to_test_optimization: ${{ github.actor != 'dependabot[bot]' }}
-      dd_sts_policy: httpd-datadog

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -60,3 +60,4 @@ jobs:
       parametric_job_count: 8
       skip_empty_scenarios: true
       push_to_test_optimization: ${{ github.actor != 'dependabot[bot]' }}
+      dd_sts_policy: httpd-datadog

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -43,7 +43,7 @@ jobs:
   main:
     needs:
       - build-artifacts
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
     secrets:
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
       DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -48,6 +48,7 @@ jobs:
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
       DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
     permissions:
+      contents: read
       id-token: write
     with:
       library: cpp_httpd

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -52,6 +52,7 @@ jobs:
       id-token: write
     with:
       library: cpp_httpd
+      ref: 1e5d6b7096279ca43ce4826fda3cc805635b63c1
       binaries_artifact: system_tests_binaries
       desired_execution_time: 300  # 5 minutes
       scenarios_groups: tracer-release


### PR DESCRIPTION
## Summary

Migrates system-tests CI to use [dd-sts](https://github.com/DataDog/dd-sts-action) for Datadog Test Optimization instead of long-lived API keys.

All repositories now share a single `system-tests` policy (see [dd-source#408172](https://github.com/DataDog/dd-source/pull/408172)) — no per-repo policy is needed.

Depends on [DataDog/system-tests#6726](https://github.com/DataDog/system-tests/pull/6726).

### Changes
- Pin system-tests to `1e5d6b709` (current `main`, pre-migration) to allow a controlled rollout: repos stay on the pre-migration workflow until their pin is explicitly updated to the post-merge SHA
