### PR TITLE
Add Dockerfile to run the integration tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git/
+build/
+build-rum/
+!build-rum/_deps/injectbrowsersdk-src/
+httpd/
+test/integration-test/.venv/
+test/integration-test/.pytest_cache/
+test/integration-test/__pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pytest==7.4.4
 requests==2.32.2
 flask==3.0.2
 msgpack==1.0.8
-git+https://github.com/Datadog/dd-apm-test-agent@v1.40.0
+git+https://github.com/Datadog/dd-apm-test-agent@v1.50.0

--- a/test/integration-test/Dockerfile
+++ b/test/integration-test/Dockerfile
@@ -1,0 +1,67 @@
+# Dockerfile for running httpd-datadog integration tests
+FROM alpine:3.21
+
+RUN apk add --no-cache \
+    autoconf \
+    build-base \
+    cmake \
+    curl \
+    expat-dev \
+    git \
+    libtool \
+    libunwind-dev \
+    linux-headers \
+    pcre2-dev \
+    python3
+
+# uv (Python package manager)
+COPY --from=ghcr.io/astral-sh/uv:0.9.28 /uv /usr/local/bin/uv
+
+# Rust toolchain (required to build the RUM module)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -yq --default-toolchain 1.73.0 \
+    && ln -s ~/.cargo/bin/cargo /usr/bin/cargo
+RUN cargo install --locked cbindgen --version 0.26.0 \
+    && ln -s ~/.cargo/bin/cbindgen /usr/local/bin/cbindgen
+
+# Apache httpd 2.4
+COPY scripts/setup-httpd.py /tmp/setup-httpd.py
+RUN python3 /tmp/setup-httpd.py -o /httpd 2.4.66 \
+    && cd /httpd \
+    && ./configure \
+        --with-included-apr \
+        --prefix=/httpd/httpd-build \
+        --enable-mpms-shared="all" \
+    && make -j$(nproc) \
+    && make install
+
+# Copy project source
+WORKDIR /workspace
+COPY . .
+
+# inject-browser-sdk is a private GitHub repository and cannot be cloned during
+# docker build. Copy the pre-fetched source from the local cmake build directory
+# and tell cmake to use it directly, bypassing the git clone.
+# Hence the following have been run locally at least once:
+# cmake --build build-rum
+COPY build-rum/_deps/injectbrowsersdk-src /inject-browser-sdk-src
+
+# Build without RUM support
+RUN cmake -B build -DHTTPD_SRC_DIR=/httpd . \
+    && cmake --build build -j$(nproc)
+
+# Build with RUM support
+RUN cmake -B build-rum \
+    -DHTTPD_SRC_DIR=/httpd \
+    -DHTTPD_DATADOG_ENABLE_RUM=ON \
+    -DFETCHCONTENT_SOURCE_DIR_INJECTBROWSERSDK=/inject-browser-sdk-src \
+    . \
+    && cmake --build build-rum -j$(nproc)
+
+# Python test dependencies
+WORKDIR /workspace/test/integration-test
+RUN uv sync
+
+# Run all integration tests by default.
+# The test suite auto-selects the correct module variant (RUM / non-RUM) per test.
+CMD ["uv", "run", "pytest", "--bin-path=/httpd/httpd-build/bin/apachectl", "-v"]

--- a/test/integration-test/README.md
+++ b/test/integration-test/README.md
@@ -2,61 +2,76 @@
 
 Integration tests for Apache httpd Datadog module using pytest.
 
-## Quick Start
+## All Tests
 
-### Setup
+All the commands below must be run from the root the repository, not from the `test/integration-test` directory:
 
-```bash
-# Install uv (Python package manager)
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Install test dependencies
-cd test/integration-test && uv sync
-
-# Run smoke tests (auto-builds module variants as needed)
-uv run pytest --bin-path=../../httpd/httpd-build/bin/apachectl -v -m smoke
-
-# Run CI tests
-uv run pytest --bin-path=../../httpd/httpd-build/bin/apachectl -v -m ci
-
-# Run RUM tests only (auto-builds with RUM support)
-uv run pytest --bin-path=../../httpd/httpd-build/bin/apachectl -v -m requires_rum
-
-# Run all tests (auto-builds module variants as needed)
-uv run pytest --bin-path=../../httpd/httpd-build/bin/apachectl -v
-
-# Run with pre-built module (skip auto-build)
-uv run pytest --bin-path=../../httpd/httpd-build/bin/apachectl -v \
-  --module-path=/path/to/mod_datadog.so
-
-# Run specific test file
-uv run pytest --bin-path=../../httpd/httpd-build/bin/apachectl -v \
-  scenarios/test_rum.py
+```sh
+cd httpd-datadog
 ```
 
-**Auto-Build Behavior:**
-- The test suite automatically builds two module variants on demand:
-  - **Without RUM**: `build/mod_datadog/mod_datadog.so` (for regular tests).
-  - **With RUM**: `build-rum/mod_datadog/mod_datadog.so` (for `@pytest.mark.requires_rum` tests).
-- Each variant is only built if tests requiring it are collected.
-- Tests automatically use the correct variant based on markers.
-- Build failures cause tests to fail (not skip).
-- Use `--module-path` to override and skip auto-build.
+### Pre-requisites
 
-## Command-Line Options
+```sh
+git submodule update --init --recursive
+cmake --build build-rum  # populates build-rum/_deps/injectbrowsersdk-src/
+```
 
-Required options:
-- `--bin-path` - Path to apachectl binary (e.g., `/usr/sbin/apachectl`)
+### Build the Docker Image
 
-Optional:
-- `--module-path` - Path to mod_datadog.so (skips auto-build if provided)
-- `--log-dir` - Directory for test logs (defaults to temp directory)
+```sh
+docker build -f test/integration-test/Dockerfile -t httpd-datadog-tests .
+```
 
-## Test Markers
+### Run All Tests
+
+```sh
+docker run --rm httpd-datadog-tests
+```
+
+### Run Tests by Markers
+
+The tests have the following optional markers:
 
 - `@pytest.mark.smoke` - Basic functionality tests
 - `@pytest.mark.ci` - CI-suitable tests
 - `@pytest.mark.requires_rum` - RUM tests (auto-build module with RUM)
+
+So, to run only smoke tests:
+
+```sh
+docker run --rm httpd-datadog-tests uv run pytest --bin-path=/httpd/httpd-build/bin/apachectl -v -m smoke
+```
+
+Similarly, to run only CI tests:
+
+```sh
+docker run --rm httpd-datadog-tests uv run pytest --bin-path=/httpd/httpd-build/bin/apachectl -v -m ci
+```
+
+### Run a Specific Test
+
+To run a specific test file:
+
+```sh
+docker run --rm httpd-datadog-tests uv run pytest --bin-path=/httpd/httpd-build/bin/apachectl -v scenarios/test_smoke.py
+```
+
+To run a specific test function:
+
+```sh
+docker run --rm httpd-datadog-tests uv run pytest --bin-path=/httpd/httpd-build/bin/apachectl -v scenarios/test_smoke.py::test_version_symbol
+```
+
+### Command-Line Options
+
+Required options:
+- `--bin-path` - Path to apachectl binary (e.g., `/usr/sbin/apachectl`)
+
+Optional options:
+- `--module-path` - Path to `mod_datadog.so` (skips auto-build if provided)
+- `--log-dir` - Directory for test logs (defaults to temp directory)
+
 
 ## RUM Tests
 
@@ -80,7 +95,7 @@ DatadogRum On
 - Child `<Location>` overrides parent.
 - Auto-builds module with `-DHTTPD_DATADOG_ENABLE_RUM=ON` when RUM tests are detected.
 
-## Docker Testing
+### Docker Testing
 
 ```sh
 docker run --rm -v "$PWD:/workspace" -w /workspace \
@@ -95,16 +110,18 @@ docker run --rm -v "$PWD:/workspace" -w /workspace \
   "
 ```
 
-## Troubleshooting
+### Troubleshooting
 
 **RUM build fails:** Check CMake output for missing dependencies (inject-browser-sdk is fetched automatically via CMake FetchContent)
 
 **Tests hang:** Port 8136 in use
+
 ```sh
 lsof -i :8136
 ```
 
 **Module issues:**
+
 ```sh
 ldd /path/to/mod_datadog.so
 apachectl -f /path/to/config.conf -t

--- a/test/integration-test/conftest.py
+++ b/test/integration-test/conftest.py
@@ -187,6 +187,7 @@ class TestAgent:
             vcr_ci_mode=False,
             vcr_provider_map="",
             vcr_ignore_headers="",
+            vcr_json_body_normalizers="",
             dd_site="",
             dd_api_key="",
             disable_llmobs_data_forwarding=False,

--- a/test/integration-test/pyproject.toml
+++ b/test/integration-test/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.8"
 dependencies = [
     "pytest>=7.4.4",
     "requests>=2.31.0",
-    "ddapm-test-agent>=1.40.0",
+    "ddapm-test-agent>=1.50.0",
     "aiohttp>=3.9.0",
     "msgpack>=1.0.0",
 ]


### PR DESCRIPTION
This introduces a `Dockerfile` to run the integration tests, and it describes how to use it in `test/integration-test/README.md`.

By the way, add new mandatory `vcr_json_body_normalizers` parameter when calling `ddapm_test_agent.agent.make_app()`.