### PR TITLE
ci: unpin system-tests (back to @main)

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -43,7 +43,7 @@ jobs:
   main:
     needs:
       - build-artifacts
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
     secrets:
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
       DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
@@ -52,7 +52,6 @@ jobs:
       id-token: write
     with:
       library: cpp_httpd
-      ref: 1e5d6b7096279ca43ce4826fda3cc805635b63c1
       binaries_artifact: system_tests_binaries
       desired_execution_time: 300  # 5 minutes
       scenarios_groups: tracer-release


### PR DESCRIPTION
Remove temporary system-tests pin (1e5d6b7 → @main) to activate dd-sts test optimization.
Tested [here](https://github.com/DataDog/httpd-datadog/actions/runs/24564575733)