### PR TITLE
Switch inject-browser-sdk to submodule; consolidate deps

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -23,10 +23,10 @@ jobs:
       image: datadog/docker-library:httpd-datadog-ci-28219c0ef3e00f1e3d5afcab61a73a5e9bd2a9b957d7545556711cce2a6262cd
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          submodules: true
       - name: Add cloned repo as safe
         run: sh -c "git config --global --add safe.directory $PWD"
+      - name: Init required submodules
+        run: git submodule update --init --depth=1 deps/dd-trace-cpp deps/nginx-datadog
       - name: Configure
         run: cmake --preset=ci-dev -B build .
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
       image: datadog/docker-library:httpd-datadog-ci-28219c0ef3e00f1e3d5afcab61a73a5e9bd2a9b957d7545556711cce2a6262cd
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          submodules: true
       - name: Add cloned repo as safe
         run: sh -c "git config --global --add safe.directory $PWD"
+      - name: Init required submodules
+        run: git submodule update --init --depth=1 deps/dd-trace-cpp deps/nginx-datadog
       - name: Configure
         run: cmake --preset ci-release -B build .
       - name: Build

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -23,10 +23,10 @@ jobs:
       image: datadog/docker-library:httpd-datadog-ci-28219c0ef3e00f1e3d5afcab61a73a5e9bd2a9b957d7545556711cce2a6262cd
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          submodules: true
       - name: Add cloned repo as safe
         run: sh -c "git config --global --add safe.directory $PWD"
+      - name: Init required submodules
+        run: git submodule update --init --depth=1 deps/dd-trace-cpp deps/nginx-datadog
       - name: Configure
         run: cmake --preset=ci-dev -B build .
       - name: Build

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = deps/nginx-datadog
 	url = ../httpd-datadog.git
 	branch = mirror-nginx-datadog
+[submodule "deps/inject-browser-sdk"]
+	path = deps/inject-browser-sdk
+	url = ../inject-browser-sdk.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,23 +23,6 @@ if (NOT HTTPD_SRC_DIR)
 endif ()
 
 include(cmake/utils.cmake)
-include(cmake/deps/fmt.cmake)
-
-if (HTTPD_DATADOG_ENABLE_RUM)
-  include(FetchContent)
-
-  set(INJECT_BROWSER_SDK_GIT_REF "49245e1c6ed8275990bb910125187e0aaad09e3d" CACHE STRING
-      "Git tag/branch for inject-browser-sdk")
-
-  FetchContent_Declare(
-    InjectBrowserSDK
-    GIT_REPOSITORY https://github.com/DataDog/inject-browser-sdk.git
-    GIT_TAG        ${INJECT_BROWSER_SDK_GIT_REF}
-  )
-  FetchContent_MakeAvailable(InjectBrowserSDK)
-
-  include(cmake/deps/rapidjson.cmake)
-endif ()
 
 add_library(httpd INTERFACE)
 target_include_directories(

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,13 @@
 
 ## Fork, Clone, Branch and Create your PR
 
-When cloning the repo, you have to initialize the submodules:
+When cloning the repo, initialize the submodules you need. For a standard build:
 
 ```sh
-git submodule update --init --recursive
+git submodule update --init deps/dd-trace-cpp deps/nginx-datadog
 ```
+
+The `deps/inject-browser-sdk` submodule is a private repo and is only required when building with `-DHTTPD_DATADOG_ENABLE_RUM=ON`. If you have access, use `--recursive` instead to pull it as well.
 
 ### Rules
 - Follow the pattern of what you already see in the code.

--- a/cmake/deps/fmt.cmake
+++ b/cmake/deps/fmt.cmake
@@ -4,15 +4,9 @@ FetchContent_Declare(
   fmt
   GIT_REPOSITORY https://github.com/fmtlib/fmt.git
   GIT_TAG        10.2.1
+  EXCLUDE_FROM_ALL
 )
 
-FetchContent_GetProperties(fmt)
-if(NOT fmt_POPULATED)
-  FetchContent_Populate(fmt)
-
-  set(BUILD_SHARED_LIBS OFF)
-  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-  add_subdirectory(${fmt_SOURCE_DIR} ${fmt_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
-
+set(BUILD_SHARED_LIBS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+FetchContent_MakeAvailable(fmt)

--- a/cmake/deps/fmt.cmake
+++ b/cmake/deps/fmt.cmake
@@ -4,14 +4,9 @@ FetchContent_Declare(
   fmt
   GIT_REPOSITORY https://github.com/fmtlib/fmt.git
   GIT_TAG        10.2.1
+  EXCLUDE_FROM_ALL
 )
 
-FetchContent_GetProperties(fmt)
-if(NOT fmt_POPULATED)
-  FetchContent_Populate(fmt)
-
-  set(BUILD_SHARED_LIBS OFF)
-  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-  add_subdirectory(${fmt_SOURCE_DIR} ${fmt_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
+set(BUILD_SHARED_LIBS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+FetchContent_MakeAvailable(fmt)

--- a/cmake/deps/fmt.cmake
+++ b/cmake/deps/fmt.cmake
@@ -4,9 +4,14 @@ FetchContent_Declare(
   fmt
   GIT_REPOSITORY https://github.com/fmtlib/fmt.git
   GIT_TAG        10.2.1
-  EXCLUDE_FROM_ALL
 )
 
-set(BUILD_SHARED_LIBS OFF)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-FetchContent_MakeAvailable(fmt)
+FetchContent_GetProperties(fmt)
+if(NOT fmt_POPULATED)
+  FetchContent_Populate(fmt)
+
+  set(BUILD_SHARED_LIBS OFF)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+  add_subdirectory(${fmt_SOURCE_DIR} ${fmt_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -8,7 +8,7 @@ add_subdirectory(dd-trace-cpp)
 set_target_properties(dd-trace-cpp-objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 if (HTTPD_DATADOG_ENABLE_RUM)
-  if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/inject-browser-sdk/CMakeLists.txt)
+  if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/inject-browser-sdk/CMakeLists.txt")
     message(FATAL_ERROR
       "deps/inject-browser-sdk submodule is not initialized. "
       "Run: git submodule update --init --recursive")

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,6 +1,22 @@
+include(${CMAKE_SOURCE_DIR}/cmake/deps/fmt.cmake)
+
 add_subdirectory(dd-trace-cpp)
 
 # Force POSITION_INDEPENDENT_CODE (PIC) because mod_datadog.so is loaded via
 # dlopen, but dd-trace-cpp sets this based on BUILD_SHARED_LIBS, whereas we
 # link with the static library.
 set_target_properties(dd-trace-cpp-objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+if (HTTPD_DATADOG_ENABLE_RUM)
+  if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/inject-browser-sdk/CMakeLists.txt)
+    message(FATAL_ERROR
+      "deps/inject-browser-sdk submodule is not initialized. "
+      "Run: git submodule update --init --recursive")
+  endif ()
+  # mod_datadog/CMakeLists.txt references ${injectbrowsersdk_SOURCE_DIR}, which
+  # FetchContent used to set; replicate it for the submodule layout.
+  set(injectbrowsersdk_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/inject-browser-sdk" CACHE INTERNAL "")
+  add_subdirectory(inject-browser-sdk EXCLUDE_FROM_ALL)
+
+  include(${CMAKE_SOURCE_DIR}/cmake/deps/rapidjson.cmake)
+endif ()


### PR DESCRIPTION
Moving back to submodule for inject-browser-sdk, as this simplifies the setup for running integration tests within a container to satisfy permissions within the container.

---

FetchContent forced cmake to clone inject-browser-sdk (private repo) at configure time, which broke devcontainer builds with no GitHub credentials. Switch to a submodule (pinned at `49245e1c6ed8`) so CI's existing `GIT_SUBMODULE_STRATEGY: recursive` and local checkouts both work with no extra auth.

While here, move fmt and the RUM wiring into `deps/CMakeLists.txt` so all third-party setup lives in one place, and simplify `fmt.cmake` to `FetchContent_MakeAvailable` now that dd-trace-cpp already forces CMake 3.28.