### PR TITLE
Respect child-scope override for tracing directives

### DIFF
--- a/mod_datadog/src/common_conf.cpp
+++ b/mod_datadog/src/common_conf.cpp
@@ -15,10 +15,15 @@ void* merge_dir_conf(apr_pool_t* pool, void* base, void* add) {
   void* final_ptr = init_dir_conf(pool, nullptr);
   auto conf = static_cast<Directory*>(final_ptr);
 
-  conf->tracing_enabled = child->tracing_enabled || parent->tracing_enabled;
+  // Tri-state merge: an explicit directive in the child scope wins over
+  // whatever the parent had (including the default). Only fall back to the
+  // parent when the child never set the directive.
+  conf->tracing_enabled =
+      child->tracing_enabled ? child->tracing_enabled : parent->tracing_enabled;
 
-  conf->trust_inbound_span =
-      child->trust_inbound_span || parent->trust_inbound_span;
+  conf->trust_inbound_span = child->trust_inbound_span
+                                 ? child->trust_inbound_span
+                                 : parent->trust_inbound_span;
 
   conf->tags = child->tags;
   auto tmp = parent->tags;

--- a/mod_datadog/src/common_conf.h
+++ b/mod_datadog/src/common_conf.h
@@ -2,6 +2,7 @@
 
 #include <datadog/tracer_config.h>
 
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -18,8 +19,11 @@ struct Module final {
 };
 
 struct Directory final {
-  bool tracing_enabled = true;
-  bool trust_inbound_span = true;
+  // `std::nullopt` means "inherit from the enclosing scope"; any concrete
+  // value (true/false) was set explicitly via a directive and wins over the
+  // parent during merge. The effective default at read sites is `true`.
+  std::optional<bool> tracing_enabled;
+  std::optional<bool> trust_inbound_span;
   std::unordered_map<std::string, std::string> tags;
 
   // RUM

--- a/mod_datadog/src/tracing/hooks.cpp
+++ b/mod_datadog/src/tracing/hooks.cpp
@@ -103,8 +103,9 @@ int on_fixups(request_rec* r, Tracer& g_tracer, module* datadog_module) {
 
     auto* dir_conf = static_cast<datadog::conf::Directory*>(
         ap_get_module_config(main_r->per_dir_config, datadog_module));
-    if (dir_conf == nullptr || !dir_conf->tracing_enabled.value_or(true))
+    if (dir_conf == nullptr || !dir_conf->tracing_enabled.value_or(true)) {
       return DECLINED;
+    }
 
     void* data = ap_get_module_config(main_r->request_config, datadog_module);
     if (!data) return DECLINED;
@@ -117,8 +118,9 @@ int on_fixups(request_rec* r, Tracer& g_tracer, module* datadog_module) {
     // Trace request
     auto* dir_conf = static_cast<datadog::conf::Directory*>(
         ap_get_module_config(r->per_dir_config, datadog_module));
-    if (dir_conf == nullptr || !dir_conf->tracing_enabled.value_or(true))
+    if (dir_conf == nullptr || !dir_conf->tracing_enabled.value_or(true)) {
       return DECLINED;
+    }
 
     void* data = ap_get_module_config(r->request_config, datadog_module);
     if (data)

--- a/mod_datadog/src/tracing/hooks.cpp
+++ b/mod_datadog/src/tracing/hooks.cpp
@@ -103,7 +103,8 @@ int on_fixups(request_rec* r, Tracer& g_tracer, module* datadog_module) {
 
     auto* dir_conf = static_cast<conf::Directory*>(
         ap_get_module_config(main_r->per_dir_config, datadog_module));
-    if (dir_conf == nullptr || !dir_conf->tracing_enabled) return DECLINED;
+    if (dir_conf == nullptr || !dir_conf->tracing_enabled.value_or(true))
+      return DECLINED;
 
     void* data = ap_get_module_config(main_r->request_config, datadog_module);
     if (!data) return DECLINED;
@@ -116,7 +117,8 @@ int on_fixups(request_rec* r, Tracer& g_tracer, module* datadog_module) {
     // Trace request
     auto* dir_conf = static_cast<datadog::conf::Directory*>(
         ap_get_module_config(r->per_dir_config, datadog_module));
-    if (dir_conf == nullptr || !dir_conf->tracing_enabled) return DECLINED;
+    if (dir_conf == nullptr || !dir_conf->tracing_enabled.value_or(true))
+      return DECLINED;
 
     void* data = ap_get_module_config(r->request_config, datadog_module);
     if (data)
@@ -127,7 +129,7 @@ int on_fixups(request_rec* r, Tracer& g_tracer, module* datadog_module) {
 
     // In case we fail to use the inbound span, then, start a new trace
     // ¯\_(ツ)_/¯ There is nothing we can do about it.
-    if (dir_conf->trust_inbound_span) {
+    if (dir_conf->trust_inbound_span.value_or(true)) {
       auto extracted_span =
           g_tracer.extract_span(utils::HeaderReader(r->headers_in), options);
       if (auto error = extracted_span.if_error()) {

--- a/mod_datadog/src/tracing/hooks.cpp
+++ b/mod_datadog/src/tracing/hooks.cpp
@@ -101,7 +101,7 @@ int on_fixups(request_rec* r, Tracer& g_tracer, module* datadog_module) {
     //       subrequests/internal redirection?
     request_rec* main_r = r->prev ? r->prev : r->main;
 
-    auto* dir_conf = static_cast<conf::Directory*>(
+    auto* dir_conf = static_cast<datadog::conf::Directory*>(
         ap_get_module_config(main_r->per_dir_config, datadog_module));
     if (dir_conf == nullptr || !dir_conf->tracing_enabled.value_or(true))
       return DECLINED;


### PR DESCRIPTION
`tracing_enabled` and `trust_inbound_span` were plain `bool`s defaulting to `true`, and `merge_dir_conf` OR'd parent with child — so `DatadogTracing Off` (or `DatadogTrustInboundSpan Off`) inside a `<Location>` was silently dropped: the enclosing scope's implicit `true` always won the OR.

Switch both `Directory` fields to `std::optional<bool>` so an explicit directive (true/false) is distinguishable from "unset" (`nullopt`). Merge now falls back to the parent only when the child never set the directive; read sites apply the default via `.value_or(true)`.

Follow-up: #65 tracks adding an integration test for `DatadogTracing Off` in a child scope (the `DatadogTrustInboundSpan` case is already covered by `test_trust_inbound_span_directive`).