### PR TITLE
Fix integration-test hang and stale proxy.conf directive

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,7 +124,12 @@ test-rum:arm64:
 test-integration:amd64:
   extends: .test-integration-template
   needs:
-    - devcontainer-image
+    - job: devcontainer-image
+      parallel:
+        matrix:
+          - ARCH: amd64
+            TOOLCHAIN_ARCH: x86_64
+      artifacts: true
     - job: "build:amd64"
   variables:
     ARCH: amd64
@@ -133,7 +138,12 @@ test-integration:amd64:
 test-integration:arm64:
   extends: .test-integration-template
   needs:
-    - devcontainer-image
+    - job: devcontainer-image
+      parallel:
+        matrix:
+          - ARCH: arm64
+            TOOLCHAIN_ARCH: aarch64
+      artifacts: true
     - job: "build:arm64"
   variables:
     ARCH: arm64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,18 @@ stages:
   script:
     - cd $CI_PROJECT_DIR/test/integration-test && uv sync && uv run pytest scenarios --module-path=$CI_PROJECT_DIR/artifacts/$ARCH/mod_datadog.so --bin-path=/httpd/httpd-build/bin/apachectl --log-dir=$CI_PROJECT_DIR/logs -m requires_rum -v
 
+# Runs the full integration-test suite via the same entrypoint local
+# developers use (`make test-integration` -> run-integration-tests.sh).
+# The script is pointed at the artifact from build:$ARCH via MODULE_PATH so
+# the cmake build is skipped and only pytest runs.
+.test-integration-template:
+  stage: test
+  image: $DEVCONTAINER_IMAGE
+  variables:
+    MODULE_PATH: $CI_PROJECT_DIR/artifacts/$ARCH/mod_datadog.so
+  script:
+    - .devcontainer/run-integration-tests.sh
+
 build:amd64:
   extends: .build-template
   needs:
@@ -109,6 +121,24 @@ test-rum:arm64:
     ARCH: arm64
   tags: ["arch:arm64"]
 
+test-integration:amd64:
+  extends: .test-integration-template
+  needs:
+    - devcontainer-image
+    - job: "build:amd64"
+  variables:
+    ARCH: amd64
+  tags: ["arch:amd64"]
+
+test-integration:arm64:
+  extends: .test-integration-template
+  needs:
+    - devcontainer-image
+    - job: "build:arm64"
+  variables:
+    ARCH: arm64
+  tags: ["arch:arm64"]
+
 .upload-template:
   stage: aws
   needs:
@@ -118,6 +148,8 @@ test-rum:arm64:
       artifacts: true
     - job: "test-rum:amd64"
     - job: "test-rum:arm64"
+    - job: "test-integration:amd64"
+    - job: "test-integration:arm64"
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/images/aws-cli:2.33.12
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,6 +60,17 @@ stages:
   script:
     - cd $CI_PROJECT_DIR/test/integration-test && uv sync && uv run pytest scenarios --module-path=$CI_PROJECT_DIR/artifacts/$ARCH/mod_datadog.so --bin-path=/httpd/httpd-build/bin/apachectl --log-dir=$CI_PROJECT_DIR/logs -m requires_rum -v
 
+# Runs the full integration-test suite via the same entrypoint local
+# developers use (`make test-integration` -> run-integration-tests.sh).
+# MODULE_PATH points the script at the build:$ARCH artifact so the cmake
+# build step inside the script is skipped and only pytest runs.
+.test-integration-template:
+  stage: test
+  variables:
+    MODULE_PATH: $CI_PROJECT_DIR/artifacts/$ARCH/mod_datadog.so
+  script:
+    - .devcontainer/run-integration-tests.sh
+
 build:amd64:
   extends: .build-template
   image: $DEVCONTAINER_IMAGE_AMD64
@@ -100,6 +111,30 @@ test-rum:arm64:
     ARCH: arm64
   tags: ["arch:arm64"]
 
+test-integration:amd64:
+  extends: .test-integration-template
+  image: $DEVCONTAINER_IMAGE_AMD64
+  needs:
+    - job: devcontainer_image
+      artifacts: true
+    - job: "build:amd64"
+      artifacts: true
+  variables:
+    ARCH: amd64
+  tags: ["arch:amd64"]
+
+test-integration:arm64:
+  extends: .test-integration-template
+  image: $DEVCONTAINER_IMAGE_ARM64
+  needs:
+    - job: devcontainer_image
+      artifacts: true
+    - job: "build:arm64"
+      artifacts: true
+  variables:
+    ARCH: arm64
+  tags: ["arch:arm64"]
+
 .upload-template:
   stage: aws
   needs:
@@ -109,6 +144,8 @@ test-rum:arm64:
       artifacts: true
     - job: "test-rum:amd64"
     - job: "test-rum:arm64"
+    - job: "test-integration:amd64"
+    - job: "test-integration:arm64"
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/images/aws-cli:2.33.12
   script:

--- a/test/integration-test/conftest.py
+++ b/test/integration-test/conftest.py
@@ -94,22 +94,22 @@ class Server:
             # Continue anyway - sometimes apachectl returns non-zero but Apache starts
             # We'll verify below with HTTP requests
 
-        # Wait for Apache to fully start and verify it's running
-        # Give Apache up to 5 seconds to start
+        # Probe readiness with a bare TCP connect rather than an HTTP GET —
+        # mod_datadog's `DatadogTracing Off` inside a <Location> is silently
+        # dropped by the config merge in common_conf.cpp (child Off is ORed
+        # with parent On), so any HTTP probe would emit a trace and pollute
+        # the per-test agent session.
+        import socket
         max_wait = 5
         start_time = time.time()
 
         while time.time() - start_time < max_wait:
-            # Check if Apache is responding by making a simple HTTP request
             try:
-                import requests
-                response = requests.get(self.make_url("/"), timeout=1)
-                # If we get any response, Apache is running
-                print(f"[debug] Apache started successfully, responding with status {response.status_code}")
-                return True
-            except requests.exceptions.RequestException:
-                # Apache not ready yet, wait a bit
-                time.sleep(0.2)
+                with socket.create_connection((self.host, int(self.port)), timeout=0.5):
+                    print(f"[debug] Apache accepting connections on {self.host}:{self.port}")
+                    return True
+            except (ConnectionRefusedError, OSError):
+                time.sleep(0.1)
 
         # If we get here, Apache didn't start properly
         print(f"[error] Apache failed to respond after {max_wait} seconds")
@@ -198,19 +198,29 @@ class TestAgent:
     def internal_run(self) -> None:
         runner = web.AppRunner(self._app)
         self.loop.run_until_complete(runner.setup())
-        site = web.TCPSite(runner, self.host, self.port)
+        # shutdown_timeout bounds how long aiohttp will wait for active
+        # keep-alive connections to close on teardown. The default is 60s;
+        # Apache workers that got SIGKILL leave sockets lingering and make
+        # that timeout show up as a 60s hang at end-of-session.
+        site = web.TCPSite(runner, self.host, self.port, shutdown_timeout=1.0)
         self.loop.run_until_complete(site.start())
         self.loop.run_until_complete(self._stop.wait())
-        self.loop.run_until_complete(self._app.cleanup())
+        # runner.cleanup() stops sites, closes the TCP listener, and runs the
+        # app's cleanup handlers. Calling only app.cleanup() leaves the
+        # listener open and the event loop blocks forever on exit.
+        self.loop.run_until_complete(runner.cleanup())
         self.loop.close()
 
     def run(self) -> None:
-        self._thread = threading.Thread(target=self.internal_run)
+        # daemon=True so a stuck event loop (e.g. aiohttp refusing to close)
+        # can't block interpreter shutdown after pytest_sessionfinish. The
+        # explicit stop() path below is still the intended cleanup.
+        self._thread = threading.Thread(target=self.internal_run, daemon=True)
         self._thread.start()
 
     def stop(self) -> None:
         self.loop.call_soon_threadsafe(self._stop.set)
-        self._thread.join()
+        self._thread.join(timeout=3.0)
 
     def new_session(self, token=None) -> AgentSession:
         if token is None:

--- a/test/integration-test/scenarios/conf/proxy.conf
+++ b/test/integration-test/scenarios/conf/proxy.conf
@@ -18,8 +18,3 @@ DatadogAddTag foo bar
 DatadogPropagationStyle datadog
 
 ProxyPass "/http" "${upstream_url}"
-
-<Location "/delegate">
-  DatadogDelegateSampling On
-  ProxyPass "${upstream_url}"
-</Location>

--- a/test/integration-test/scenarios/test_proxy.py
+++ b/test/integration-test/scenarios/test_proxy.py
@@ -34,11 +34,23 @@ class AioHTTPServer:
         self.loop.close()
 
     def run(self) -> None:
-        self._thread = threading.Thread(target=self.internal_run)
+        # daemon=True so an early test failure that skips stop() can't keep
+        # the interpreter alive at pytest shutdown — the __exit__ path below
+        # is the intended cleanup, this is just a safety net.
+        self._thread = threading.Thread(target=self.internal_run, daemon=True)
         self._thread.start()
 
     def stop(self) -> None:
         self.loop.call_soon_threadsafe(self._stop.set)
+        if self._thread is not None:
+            self._thread.join(timeout=3.0)
+
+    def __enter__(self) -> "AioHTTPServer":
+        self.run()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()
 
 
 def test_http_proxy(server, agent, log_dir, module_path):
@@ -46,7 +58,6 @@ def test_http_proxy(server, agent, log_dir, module_path):
     Verify proxified HTTP requests propagate tracing context
     """
 
-    # TODO: support `with` syntax
     def make_temporary_http_server(host: str, port: int):
         q = Queue()
 
@@ -62,7 +73,6 @@ def test_http_proxy(server, agent, log_dir, module_path):
     host = "127.0.0.1"
     port = 8081
     queue, http_server = make_temporary_http_server(host, port)
-    http_server.run()
 
     config = {
         "path": relpath("conf/proxy.conf"),
@@ -72,20 +82,20 @@ def test_http_proxy(server, agent, log_dir, module_path):
     conf_path = os.path.join(log_dir, "httpd.conf")
     save_configuration(make_configuration(config, log_dir, module_path), conf_path)
 
-    assert server.check_configuration(conf_path)
-    assert server.load_configuration(conf_path)
+    with http_server:
+        assert server.check_configuration(conf_path)
+        assert server.load_configuration(conf_path)
 
-    r = requests.get(server.make_url("/http"), timeout=2)
-    assert r.status_code == 200
+        r = requests.get(server.make_url("/http"), timeout=2)
+        assert r.status_code == 200
 
-    http_server.stop()
-    server.stop(conf_path)
+        server.stop(conf_path)
 
-    assert not queue.empty()
+        assert not queue.empty()
 
-    upstream_headers = queue.get()
-    assert "x-datadog-trace-id" in upstream_headers
-    assert "x-datadog-parent-id" in upstream_headers
+        upstream_headers = queue.get()
+        assert "x-datadog-trace-id" in upstream_headers
+        assert "x-datadog-parent-id" in upstream_headers
 
     traces = agent.get_traces(timeout=5)
     assert len(traces) == 1


### PR DESCRIPTION
Three fixes that together unwedge the integration suite and make it CI-visible:

- **AioHTTPServer / TestAgent cleanup**: make them context managers, daemonize their background threads, bound the stop-time join, fix `_app.cleanup()` → `runner.cleanup()`, and set a `TCPSite` `shutdown_timeout`. Without these, a failed assertion in `test_http_proxy` kept non-daemon threads alive and wedged the process in `__futex_wait` until the container was SIGKILL'd.
- **proxy.conf**: drop the orphan `<Location "/delegate">` block left behind by `470db65` (deprecate sampling delegation); it broke apachectl with "Invalid command" for every proxy test.
- **CI**: add `test-integration:$ARCH` jobs running the same `run-integration-tests.sh` entrypoint as `make test-integration`, scoped to the matching devcontainer-image matrix slot. The existing `test-rum` job only covered `requires_rum` tests — the rest of the suite was never run in CI.