### PR TITLE
Rewrite readiness-probe comment to be bug-agnostic

### DIFF
--- a/test/integration-test/conftest.py
+++ b/test/integration-test/conftest.py
@@ -94,11 +94,11 @@ class Server:
             # Continue anyway - sometimes apachectl returns non-zero but Apache starts
             # We'll verify below with HTTP requests
 
-        # Probe readiness with a bare TCP connect rather than an HTTP GET —
-        # mod_datadog's `DatadogTracing Off` inside a <Location> is silently
-        # dropped by the config merge in common_conf.cpp (child Off is ORed
-        # with parent On), so any HTTP probe would emit a trace and pollute
-        # the per-test agent session.
+        # Probe readiness with a bare TCP connect rather than an HTTP GET:
+        # HTTP probes run through mod_datadog's handlers and can emit a
+        # trace into the per-test agent session, contaminating assertions
+        # tests make about per-request trace counts. A raw TCP connect
+        # doesn't reach any request handler, so it stays out of traces.
         import socket
         max_wait = 5
         start_time = time.time()


### PR DESCRIPTION
The readiness-probe comment cited a specific bug in the `DatadogTracing Off` scope-merge path to justify using TCP over HTTP. That bug is fixed earlier in this stack, so the comment now reads as if a live bug is still in the tree.

Restate the rationale bug-agnostically: any HTTP probe runs through the module's handlers and can emit a trace into the per-test agent session; a bare TCP connect can't. This stays true regardless of future mod_datadog changes.