### PR TITLE
Release v1.0.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # - toolchain (msvc, llvm, gcc)
 cmake_minimum_required(VERSION 3.12)
 
-project(httpd-datadog VERSION 1.0.4)
+project(httpd-datadog VERSION 1.0.5)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
Prepare release `v1.0.5`, while updating `dd-trace-cpp` to [v2.1.0](https://github.com/DataDog/dd-trace-cpp/releases/tag/v2.1.0).