### PR TITLE
Pin the version of the datadog-ci npm package used for code coverage upload

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -71,6 +71,8 @@ jobs:
           llvm-profdata merge -sparse /tmp/*.profraw -o /tmp/default.profdata
           llvm-cov export dist/lib/mod_datadog.so -format=lcov -instr-profile=/tmp/default.profdata -ignore-filename-regex=/httpd/ > coverage.lcov
       - name: Upload code coverage report to Datadog
-        run: npx @datadog/datadog-ci@latest coverage upload --format=lcov coverage.lcov
+        run: |
+          # datadog-ci package comes from https://www.npmjs.com/package/@datadog/datadog-ci?activeTab=versions
+          npx @datadog/datadog-ci@5.18.0 coverage upload --format=lcov coverage.lcov
         env:
           DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -73,6 +73,4 @@ jobs:
       - name: Upload code coverage report to Datadog
         run: |
           # datadog-ci package comes from https://www.npmjs.com/package/@datadog/datadog-ci?activeTab=versions
-          npx @datadog/datadog-ci@5.18.0 coverage upload --format=lcov coverage.lcov
-        env:
-          DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
+          npx --yes @datadog/datadog-ci@5.18.0 coverage upload --format=lcov coverage.lcov


### PR DESCRIPTION
This is a mitigation of the supply chain vulnerability described in [APMSP-3392 Unpinned npx coverage uploader runs with CI API key](https://datadoghq.atlassian.net/browse/APMSP-3392): pin the version for the `datadog-ci` npm package use for code coverage upload.