### PR TITLE
Removes legacy secrets

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -44,9 +44,6 @@ jobs:
     needs:
       - build-artifacts
     uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
-    secrets:
-      TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
-      DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
This API key should ne be present anymore in our repo secrets. system-tests ships a mechanism to get the key for test optim, and does not require any more a key for testing.