### PR TITLE
[codex] Use direct S3-backed sccache in GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,6 @@ stages:
     SCCACHE_BUCKET: dd-sccache-storage-us1-ddbuild-io
     SCCACHE_REGION: us-east-1
     SCCACHE_S3_KEY_PREFIX: httpd-datadog
-    SCCACHE_S3_USE_SSL: "true"
     RUSTC_WRAPPER: /usr/bin/sccache
   # The GitLab repository identity has read/write access only to this
   # repository's prefix in the shared sccache bucket.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,18 +42,13 @@ stages:
     GIT_SUBMODULE_STRATEGY: normal
     GIT_SUBMODULE_PATHS: "deps/dd-trace-cpp deps/inject-browser-sdk"
     GIT_SUBMODULE_UPDATE_FLAGS: "--jobs 2"
-    SCCACHE_DIR: $CI_PROJECT_DIR/.cache/sccache
-    SCCACHE_CACHE_SIZE: 1G
-    CACHE_COMPRESSION_LEVEL: fastest
+    SCCACHE_BUCKET: dd-sccache-storage-us1-ddbuild-io
+    SCCACHE_REGION: us-east-1
+    SCCACHE_S3_KEY_PREFIX: httpd-datadog
+    SCCACHE_S3_USE_SSL: "true"
     RUSTC_WRAPPER: /usr/bin/sccache
-  # The runner moves sccache's already-compressed local objects through its
-  # shared S3 backend using pre-signed URLs, so ephemeral pods need no direct
-  # bucket permissions. Separate writers avoid cross-architecture races.
-  cache:
-    key: "sccache-v1-${ARCH}"
-    paths:
-      - .cache/sccache/
-    policy: pull-push
+  # The GitLab repository identity has read/write access only to this
+  # repository's prefix in the shared sccache bucket.
   needs:
     - job: devcontainer_image
       artifacts: true


### PR DESCRIPTION
## What changed

- configure sccache to use the shared `dd-sccache-storage-us1-ddbuild-io` S3 bucket
- scope cache objects to the authorized `httpd-datadog` prefix
- remove the GitLab cache archive used to transport the local sccache directory

## Why

DataDog/cloud-inventory#66909 grants the `httpd-datadog` GitLab repository identity read/write access to its isolated prefix in the shared sccache bucket. Using the S3 backend directly avoids downloading and uploading the entire cache archive for every build job.

## Impact

The existing C, C++, and Rust compiler wrappers continue to use sccache. Cache entries are now shared directly through S3 while remaining isolated from other repositories.

## Validation

- parsed `.gitlab-ci.yml` with Ruby/Psych
- `git diff --check`

Related: DataDog/cloud-inventory#66909
